### PR TITLE
Verschlüsselung des Passworts und (kleine) Anti-Brute-Methode

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,44 +1,5 @@
-# Covers JetBrains IDEs: IntelliJ, RubyMine, PhpStorm, AppCode, PyCharm, CLion, Android Studio and Webstorm
-# Reference: https://intellij-support.jetbrains.com/hc/en-us/articles/206544839
-
-# User-specific stuff:
-.idea/workspace.xml
-.idea/tasks.xml
-
-# Sensitive or high-churn files:
-.idea/dataSources.ids
-.idea/dataSources.xml
-.idea/dataSources.local.xml
-.idea/sqlDataSources.xml
-.idea/dynamic.xml
-.idea/uiDesigner.xml
-
-# Gradle:
-.idea/gradle.xml
-.idea/libraries
-
-# Mongo Explorer plugin:
-.idea/mongoSettings.xml
-
-## File-based project format:
-*.iws
-
-## Plugin-specific files:
-
-# IntelliJ
-/out/
-
-# mpeltonen/sbt-idea plugin
-.idea_modules/
-
-# JIRA plugin
-atlassian-ide-plugin.xml
-
-# Crashlytics plugin (for Android Studio and IntelliJ)
-com_crashlytics_export_strings.xml
-crashlytics.properties
-crashlytics-build.properties
-fabric.properties
+# PhpStorm
+.idea/*
 
 # APPLE MAC SPECIFIC:
 *.DS_Store

--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,69 @@
+# Covers JetBrains IDEs: IntelliJ, RubyMine, PhpStorm, AppCode, PyCharm, CLion, Android Studio and Webstorm
+# Reference: https://intellij-support.jetbrains.com/hc/en-us/articles/206544839
+
+# User-specific stuff:
+.idea/workspace.xml
+.idea/tasks.xml
+
+# Sensitive or high-churn files:
+.idea/dataSources.ids
+.idea/dataSources.xml
+.idea/dataSources.local.xml
+.idea/sqlDataSources.xml
+.idea/dynamic.xml
+.idea/uiDesigner.xml
+
+# Gradle:
+.idea/gradle.xml
+.idea/libraries
+
+# Mongo Explorer plugin:
+.idea/mongoSettings.xml
+
+## File-based project format:
+*.iws
+
+## Plugin-specific files:
+
+# IntelliJ
+/out/
+
+# mpeltonen/sbt-idea plugin
+.idea_modules/
+
+# JIRA plugin
+atlassian-ide-plugin.xml
+
+# Crashlytics plugin (for Android Studio and IntelliJ)
+com_crashlytics_export_strings.xml
+crashlytics.properties
+crashlytics-build.properties
+fabric.properties
+
+# APPLE MAC SPECIFIC:
+*.DS_Store
+.AppleDouble
+.LSOverride
+
+# Icon must end with two \r
+Icon
+
+
+# Thumbnails
+._*
+
+# Files that might appear in the root of a volume
+.DocumentRevisions-V100
+.fseventsd
+.Spotlight-V100
+.TemporaryItems
+.Trashes
+.VolumeIcon.icns
+.com.apple.timemachine.donotpresent
+
+# Directories potentially created on remote AFP share
+.AppleDB
+.AppleDesktop
+Network Trash Folder
+Temporary Items
+.apdisk

--- a/.gitignore
+++ b/.gitignore
@@ -28,3 +28,6 @@ Icon
 Network Trash Folder
 Temporary Items
 .apdisk
+
+
+config.php

--- a/README.md
+++ b/README.md
@@ -7,7 +7,10 @@ CoCal ist ein Calender Sync Service für CAMPUS-Office. Mithilfe von CoCal kann 
 
 CoCal benötigt einen Webserver mit PHP sowie deren cURL-Erweiterung. Alles weitere ist in diesem Repository enthalten.
 
-CoCal muss nicht gesondert eingerichtet werden. Lade es einfach in das Verzeichnis deines Webservers und du kannst loslegen.
+CoCal muss zusätzlich noch installiert werden um einen Verschlüsselungs-Key zu generieren. Lade es einfach in das Verzeichnis deines Webservers und öffne die Seite ```install.php``` in einem Browser und klicke dort auf den Install-Button.
+Nach der Installation muss die Installations-Datei noch gelöscht werden und schon kannst du Cocal benutzen.
+
+Beachte, dass PHP genügend Rechte hat, um im Hauptverzeichnis Dateien anzulegen und hinein zu schreiben. Dies ist notwendig, damit die Config-File angelegt werden kann.
 
 
 ### nginx-Konfiguration
@@ -138,3 +141,5 @@ CoCal ist unter der freien [GPLv3](http://www.gnu.org/licenses/gpl-3.0.en.html) 
 Copyright 2011-2015 [Steffen Vogel](http://www.steffenvogel.de/)
 
 Copyright 2015 [Alexander Haase](mailto:alexander.haase@rwth-aachen.de)
+
+Copyright 2016 [Loïc Beurlet](https://github.com/Lozik)

--- a/calendar.php
+++ b/calendar.php
@@ -1,116 +1,32 @@
 <?php
-
-/*
- * helper functions
- */
-
-/** \brief Print an error message and exit PHP script.
- *
- * \param errno HTTP Error code.
- * \param errormsg Optional error message to be displayed in error.php.
- *
- * \return This function never returns.
- */
-function error($errno, $errormsg = NULL)
-{
-	$err_string = array(
-		400 => "Bad Request",
-		500 => "Internal Server Error"
-	);
-
-	// set HTTP header for error message
-	if (isset($err_string[$errno]))
-		header("HTTP/1.0 $errno ".$err_string[$errno]);
-
-	include("error.php");
-	die();
+require_once('includes.php');
+if (file_exists('config.php') && file_exists('install.php')) {
+	error(500, "Vor dem Benutzen von Cocal muss die install.php file gelöscht werden.");
 }
-
-
-/** \brief Reset cURL handle and set default options.
- *
- * \return Returns nothing on success. Otherwise an error message will be
- *  displayed and PHP dies.
- */
-function curl_reset_handle($curl_handle)
-{
-	// reset cURL handle
-	curl_reset($curl_handle);
-
-	// enable cookie engine
-	$options = array(
-		CURLOPT_COOKIESESSION => true,
-		CURLOPT_COOKIEJAR => "/dev/null"
-	);
-
-	if (!curl_setopt_array($curl_handle, $options))
-		error(500, "cURL Cookie-engine konnte nicht initialisiert werden.");
+else if (!file_exists('config.php')) {
+	error(500, "Vor dem Benutzen von Cocal muss Cocal <a href='install.php'>installiert werden</a>.");
 }
-
-
-/** \brief Perform a cURL request.
- *
- * \param curl_handle cURL handle.
- * \param url URL for request to be performed.
- * \param method HTTP request method (GET or POST).
- * \param params Optional parameters for GET and POST reqests.
- *
- * \return On success the requested data will be returned. On failure an error
- *  message will be displayed and PHP dies.
- */
-function curl_request($curl_handle, $url, $method = "GET", $params = array())
-{
-	// reset cURL handle
-	curl_reset_handle($curl_handle);
-
-	// convert params
-	$param_string = "";
-	foreach($params as $key => $value)
-		$param_string .= $key.'='.urlencode($value).'&';
-
-	rtrim($param_string, '&');
-
-	// set cURL options
-	$options = array(
-		CURLOPT_URL => $url,
-		CURLOPT_FOLLOWLOCATION => true,
-		CURLOPT_RETURNTRANSFER => true
-	);
-
-	// set params for method
-	if ($method == "POST") {
-		$options[CURLOPT_POST] = count($params);
-		$options[CURLOPT_POSTFIELDS] = $param_string;
-
-	} else if ($method == "GET") {
-		$options[CURLOPT_URL] .= "?".$param_string;
-	}
-
-	// set all options
-	if (!curl_setopt_array($curl_handle, $options))
-		error(500, "cURL optionen konnten nicht gesetzt werden.");
-
-	// execute request
-	$result = curl_exec($curl_handle);
-	if ($result == false)
-		error(500, "Fehler bei der Kommunikation mit CAMPUS office.");
-
-	return $result;
-}
-
-
-
+require_once('config.php');
 /*
  * Implementation
  */
 
 /* Decode hash.
- * Hash is in HTML BASIC auth format base64(user:pass).
+ * Hash is encrypted by encryptUrlData().
  */
+if ($_GET['v'] == 2 && (!isset($_GET['pass']) || empty($_GET['pass']) || $_GET['pass'] != URLPASSWORD))
+{
+	error(400, "Security code Falsch!");
+}
 if (!isset($_GET['hash']) || empty($_GET['hash']))
 	error(400, "Parameter 'hash' nicht angegeben!");
 
-$cipher = base64_decode($_GET['hash']);
+if($_GET['v'] == 2) {
+	$cipher = decryptUrlData($_GET['hash']);
+}
+else {
+	$cipher = base64_decode($_GET['hash']);
+}
 if (!strpos($cipher, ':'))
 	error(400, "Hash ist ung&uuml;ltig!");
 

--- a/calendar.php
+++ b/calendar.php
@@ -123,7 +123,7 @@ unset($cipher);
  * will be loaded from file config/<provider>.json.
  */
 if (!isset($_GET['provider']))
-	error(400, "Parameter 'co' nicht angegeben!");
+	error(400, "Parameter 'provider' nicht angegeben!");
 
 $config = json_decode(file_get_contents("./config/".$_GET['provider'].".json"),
                       true);

--- a/config.php.dist
+++ b/config.php.dist
@@ -1,0 +1,7 @@
+<?php
+/**
+ * This is an automatically generated file. Manual modifications may be overwritten. Handle with care.
+ * Last modification: dd.mm.YYYY HH:ii:ss
+ */
+define('CRYPTPASSWORD', base64_decode('XXXXXXX'));
+define('URLPASSWORD', 'XXXXXXX');

--- a/generateHash.php
+++ b/generateHash.php
@@ -1,0 +1,31 @@
+<?php
+require_once('includes.php');
+if (file_exists('config.php') && file_exists('install.php')) {
+    error(500, "Vor dem Benutzen von Cocal muss die install.php file gelöscht werden.");
+}
+else if (!file_exists('config.php')) {
+    error(500, "Vor dem Benutzen von Cocal muss Cocal <a href='install.php'>installiert werden</a>.");
+}
+require_once('config.php');
+header('Content-Type: application/json');
+$response = "error";
+$message = "";
+$hash = "";
+if(!isset($_POST['token']) || empty($_POST['token'])) {
+    $message = "Fehler! Lehre Anfrage.";
+}
+else if($_POST['token'] != $_SESSION['cocalRequestToken']) {
+    $message = "Fehler! Die Anfrage wurde sicherheitshalber nicht angenommen.";
+}
+else if(empty($_POST['username']) || empty($_POST['password'])) {
+    $message = "Fehler! Die Anfrage war nicht vollständig.";
+}
+else {
+    $response = "success";
+    $hash = encryptUrlData($_POST['username'] . ':' . $_POST['password']);
+}
+echo json_encode(array(
+    'response' => $response,
+    'message' => $message,
+    'hash' => $hash
+    ));

--- a/includes.php
+++ b/includes.php
@@ -1,0 +1,121 @@
+<?php
+session_start();
+define('AES_256_CBC', 'aes-256-cbc');
+/*
+ * helper functions
+ */
+
+/** \brief Print an error message and exit PHP script.
+ *
+ * \param errno HTTP Error code.
+ * \param errormsg Optional error message to be displayed in error.php.
+ *
+ * \return This function never returns.
+ */
+function error($errno, $errormsg = NULL)
+{
+    $err_string = array(
+        400 => "Bad Request",
+        500 => "Internal Server Error"
+    );
+
+    // set HTTP header for error message
+    if (isset($err_string[$errno]))
+        header("HTTP/1.0 $errno ".$err_string[$errno]);
+
+    include("error.php");
+    die();
+}
+
+
+/** \brief Reset cURL handle and set default options.
+ *
+ * \return Returns nothing on success. Otherwise an error message will be
+ *  displayed and PHP dies.
+ */
+function curl_reset_handle($curl_handle)
+{
+    // reset cURL handle
+    curl_reset($curl_handle);
+
+    // enable cookie engine
+    $options = array(
+        CURLOPT_COOKIESESSION => true,
+        CURLOPT_COOKIEJAR => "/dev/null"
+    );
+
+    if (!curl_setopt_array($curl_handle, $options))
+        error(500, "cURL Cookie-engine konnte nicht initialisiert werden.");
+}
+
+
+/** \brief Perform a cURL request.
+ *
+ * \param curl_handle cURL handle.
+ * \param url URL for request to be performed.
+ * \param method HTTP request method (GET or POST).
+ * \param params Optional parameters for GET and POST reqests.
+ *
+ * \return On success the requested data will be returned. On failure an error
+ *  message will be displayed and PHP dies.
+ */
+function curl_request($curl_handle, $url, $method = "GET", $params = array())
+{
+    // reset cURL handle
+    curl_reset_handle($curl_handle);
+
+    // convert params
+    $param_string = "";
+    foreach($params as $key => $value)
+        $param_string .= $key.'='.urlencode($value).'&';
+
+    rtrim($param_string, '&');
+
+    // set cURL options
+    $options = array(
+        CURLOPT_URL => $url,
+        CURLOPT_FOLLOWLOCATION => true,
+        CURLOPT_RETURNTRANSFER => true
+    );
+
+    // set params for method
+    if ($method == "POST") {
+        $options[CURLOPT_POST] = count($params);
+        $options[CURLOPT_POSTFIELDS] = $param_string;
+
+    } else if ($method == "GET") {
+        $options[CURLOPT_URL] .= "?".$param_string;
+    }
+
+    // set all options
+    if (!curl_setopt_array($curl_handle, $options))
+        error(500, "cURL optionen konnten nicht gesetzt werden.");
+
+    // execute request
+    $result = curl_exec($curl_handle);
+    if ($result == false)
+        error(500, "Fehler bei der Kommunikation mit CAMPUS office.");
+
+    return $result;
+}
+function encryptUrlData($data)
+{
+    $iv = openssl_random_pseudo_bytes(openssl_cipher_iv_length(AES_256_CBC));
+    $key = openssl_encrypt($data, AES_256_CBC, CRYPTPASSWORD, 0, $iv).':'.$iv;
+    return base64_encode($key);
+}
+function decryptUrlData($data)
+{
+    $vars = explode(':', base64_decode($data));
+    return openssl_decrypt($vars[0], AES_256_CBC, CRYPTPASSWORD, 0, $vars[1]);
+}
+function randomString($num) {
+    $chars = "0123456789abcdefghijklmnopqrstuvwxyzABCDEFGHIJKLMNOPQRSTUVWXYZ-";
+    $str = "";
+
+    for ($i = 0; $i < $num; $i++) {
+        $str .= $chars[mt_rand(0, strlen($chars) - 1)];
+    }
+
+    return $str;
+}

--- a/index.php
+++ b/index.php
@@ -89,9 +89,8 @@ if (!empty($dir))
 		<p>
 			Der generierte Link ist f&uuml;r dich <b>pers&ouml;nlich</b>
 			gedacht. Er enth&auml;lt deine pers&ouml;nlichen CAMPUS-Office
-			Anmeldedaten und gew&auml;hrt jedem Zugriff auf deinen CAMPUS-Office
-			Account. Bewahre ihn daher sicher auf, oder generiere ihn am besten
-			nur, wenn du ihn gerade brauchst und schreibe ihn nicht auf.
+			Anmeldedaten in verschlüsselter Form und gew&auml;hrt jedem Zugriff auf deinen CAMPUS-Office
+			Kalender. Der Link ist ohne Gegenschlüssel (Server-Intern) unbrauchbar. Bewahre ihn jedoch trotzdem sicher auf.
 		</p>
 		<p>
 			Solltest du den Link versehentlich weitergegeben haben oder ein
@@ -101,15 +100,24 @@ if (!empty($dir))
 
 		<h2>Datenschutz</h2>
 		<p>
-			Auf dem CoCal Server werden keine Passwort-Hashes gespeichert. Auch
+			Auf dem CoCal Server werden keine persönlichen Passwort-Hashes gespeichert. Es wird lediglich ein
+			Entschlüsselungs-Hash gespeichert, der komplett unabhängig von deinem Passwort im Vorhinein generiert wurde. Auch
 			wenn von diesem Server Daten geklaut werden, kann dein Passwort also
-			nicht geklaut werden.<br/>
+			nicht geklaut werden. Man braucht immer Passwort-Hash und Entschlüsselungs-Hash, um deine Anmeldedaten zu
+			Klartext zu entschlüsseln.<br/>
 
 			Wenn du dem Admin des Servers jedoch nicht traust, dass er
 			sorgf&auml;ltig mit deinen Daten umgeht, kannst du CoCal auch
 			einfach <a href="https://github.com/alehaa/cocal">auf deinem
 			eigenen Server hosten.</a>
 		</p>
+		<h2>Alte Version</h2>
+		<p>Damit die alten Links, die du in der Vergangenheit generiert hast mit der aktuellen Version auch noch funktionieren,
+		ist diese Cocal-Version backwards compatible. Allerdings muss man <b>unbedingt beachten</b>, dass die <b>älteren Links</b> noch
+		deine kompletten Anmeldedaten <b>ohne Verschlüsselung</b> beinhalten. Jeder, der deinen alten Link kennt, kennt automatisch deine
+		Anmeldedaten.<br>
+		Aktuell werden nur noch verschlüsselte Links generiert. Wenn du dir also nicht sicher bist,
+			ob du einen neuen oder alten Link hast, generiere dir einen neuen! (Neue Links enthalten die Zeichenkette <code>&v=2</code>.)</p>
 
 
 		<h1 id="generator">CoCal nutzen</h1>
@@ -176,8 +184,9 @@ foreach ($files as $file) {
 				Dein pers&ouml;nlicher Link f&uuml;r dein Kalender-Abonement:<br/>
 				<a id="generator_url_link"></a><br/>
 				<br/>
-				<b>Achtung:</b> Gebe diesen Link an <b>niemanden</b> weiter, da
-				er deine pers&ouml;nlichen CAMPUS-Anmeldedaten enth&auml;lt!
+				Dieser Link enthällt deine <b>persönlichen CAMPUS-Anmeldedaten</b>. Jedoch wurden diese zuvor verschlüsselt,
+				damit deine Daten ohne Gegenschlüssel nicht entschlüsselbar sind.
+				Wir empfehlen trotzdem, dass du beim Verlust des Links deine <b>Anmeldedaten änderst</b>.
 			</p>
 		</div>
 
@@ -190,8 +199,9 @@ foreach ($files as $file) {
 
 		<h1 id="contribute">Mitwirken</h1>
 		<p>
-			CoCal wurde von <a href="http://www.steffenvogel.de">Steffen Vogel</a>
-			und <a href="https://github.com/alehaa">Alexander Haase</a>
+			CoCal wurde von <a href="http://www.steffenvogel.de" target="_blank">Steffen Vogel</a>,
+			<a href="https://github.com/alehaa" target="_blank">Alexander Haase</a> und
+			<a href="https://github.com/Lozik" target="_blank">Loïc Beurlet</a>
 			geschrieben.
 		</p>
 		<p>

--- a/index.php
+++ b/index.php
@@ -1,3 +1,15 @@
+<?php
+require_once('includes.php');
+if (file_exists('config.php') && file_exists('install.php')) {
+	error(500, "Vor dem Benutzen von Cocal muss die install.php file gelöscht werden.");
+}
+else if (!file_exists('config.php')) {
+	error(500, "Vor dem Benutzen von Cocal muss Cocal <a href='install.php'>installiert werden</a>.");
+}
+require_once('config.php');
+$token = randomString(20);
+$_SESSION['cocalRequestToken'] = $token;
+?>
 <!DOCTYPE html>
 <html>
 <head>
@@ -41,6 +53,7 @@ if (!empty($dir))
 	$url .= "/".$dir;
 ?>
 		var cocal_proxy_url = "<?php echo($url); ?>";
+		var securityCode = "<?php echo URLPASSWORD; ?>";
 	</script>
 </head>
 
@@ -133,6 +146,7 @@ foreach ($files as $file) {
 					</select>
 				</div>
 			</div>
+			<input type="hidden" id="cocal_token" value="<?php echo $token ?>">
 			<div class="form-group">
 				<label for="cocal_user" class="col-sm-2 control-label">Benutzername</label>
 				<div class="col-sm-4">

--- a/install.php
+++ b/install.php
@@ -1,0 +1,45 @@
+<?php
+require_once('includes.php');
+if (file_exists('config.php') && file_exists('install.php')) {
+    error(500, "Vor dem Benutzen von Cocal muss die install.php file gelöscht werden.");
+}
+if(isset($_POST['install'])) {
+    $newKey = openssl_random_pseudo_bytes(32);
+    $newPassword = randomString(20);
+    $configFileExisted = false;
+    if (file_exists('config.php')) {
+        $configFileExisted = true;
+        rename('config.php', 'config.php~')
+            or error(500, "Fehler bei der Konfiguration. Bitte beachten, dass die config.php file schreibbar sein muss.");
+    }
+    $fd = fopen('config.php', "w")
+    or error(500, "Fehler bei der Konfiguration. Bitte beachten, dass die config.php file schreibbar sein muss.");
+    $fileContent = "<?php
+        /**
+        * This is an automatically generated file. Manual modifications may be overwritten. Handle with care.
+        * Last modification: " . date('d.m.Y H:i:s') . "
+        */\n";
+    $fileContent .= "\t".'define(\'CRYPTPASSWORD\', base64_decode(\'' . base64_encode($newKey) . '\'));' . "\n";
+    $fileContent .= "\t".'define(\'URLPASSWORD\', \'' . $newPassword . '\');' . "\n";
+    fwrite($fd, $fileContent);
+    fclose($fd);
+    $progress = 100;
+    $content = '<div class="panel panel-success"><div class="panel-heading">
+                <h3 class="panel-title">Installation erfolgreich</h3>
+                </div>
+                <div class="panel-body">
+                Die Cocal-Installation wurde erfolgreich abgeschlossen. <b>Bitte löschen Sie jetzt install.php.</b>
+                </div>
+                </div>';
+}
+else {
+    //if (file_exists('config.php') && file_exists('install.php')) { error(500, "Vor dem Benutzen von Cocal muss die install.php file gelöscht werden."); }
+    $progress = 10;
+    $content = '<form action="" method="post"><input type="hidden" name="install">
+                <p>Um Cocal benutzen zu können, müssen ein privater Schlüssel und ein URL Passwort generiert werden. 
+                Um Cocal zu installieren, einfach auf folgenden Button klicken:</p>
+                <p><button class="btn btn-primary" type="submit"><span class="glyphicon glyphicon-cog"></span>
+                    Cocal installieren</button></p></form>';
+}
+
+require_once('installTemplate.php');

--- a/installTemplate.php
+++ b/installTemplate.php
@@ -1,0 +1,58 @@
+<?php if(!isset($progress)) {
+    header("HTTP/1.1 403 Unauthorized");
+    exit('<html><head>
+            <title>403 Forbidden</title>
+            </head><body>
+            <h1>Forbidden</h1>
+            <p>You don\'t have permission to access this page.</p>
+            </body></html>');
+} ?>
+<!DOCTYPE html>
+<html>
+<head>
+    <meta charset="utf-8">
+    <meta http-equiv="X-UA-Compatible" content="IE=edge">
+    <meta name="viewport" content="width=device-width, initial-scale=1">
+    <!-- The above 3 meta tags *must* come first in the head; any other head content must come *after* these tags -->
+
+    <title>CoCal installieren</title>
+
+    <!-- jQuery -->
+    <script src="https://ajax.googleapis.com/ajax/libs/jquery/1.11.3/jquery.min.js"></script>
+
+    <!-- Bootstrap -->
+    <link href="css/bootstrap.min.css" rel="stylesheet">
+    <script src="js/bootstrap.min.js"></script>
+
+    <!-- HTML5 shim and Respond.js for IE8 support of HTML5 elements and media queries -->
+    <!-- WARNING: Respond.js doesn't work if you view the page via file:// -->
+    <!--[if lt IE 9]>
+    <script src="https://oss.maxcdn.com/html5shiv/3.7.2/html5shiv.min.js"></script>
+    <script src="https://oss.maxcdn.com/respond/1.4.2/respond.min.js"></script>
+    <![endif]-->
+
+    <!-- CoCal -->
+    <link href="css/cocal.css" rel="stylesheet">
+</head>
+
+<body>
+<nav class="navbar navbar-inverse navbar-fixed-top">
+    <div class="container">
+        <div class="navbar-header">
+            <a class="navbar-brand" href="#">CoCal</a>
+        </div>
+
+    </div>
+</nav>
+
+<div class="container">
+    <h1 id="home">CoCal installieren</h1>
+    <div class="progress">
+        <div class="progress-bar progress-bar-success" role="progressbar" aria-valuenow="<?php echo $progress; ?>" aria-valuemin="0" aria-valuemax="100" style="width: <?php echo $progress; ?>%;">
+            <span class="sr-only">0% Complete</span>
+        </div>
+    </div>
+    <?php echo $content; ?>
+</div>
+</body>
+</html>

--- a/js/cocal.js
+++ b/js/cocal.js
@@ -1,12 +1,41 @@
 function cocal_encode_url() {
-	// encode user and pass seperated by colon with base64 for HTML BASIC auth
-	var campus_login_hash = btoa($('#cocal_user').val() + ':' + $('#cocal_pass').val());
 
-	// generate complete URL
-	var url = cocal_proxy_url + "/calendar.php?provider=" + $('#cocal_provider').val() + "&hash=" + campus_login_hash;
+	if(!$('#cocal_user').val() || !$('#cocal_pass').val())
+	{
+		alert('Du musst einen Benutzernamen und ein Passwort angeben.')
+	}
+	else {
+		var formData = new FormData();
+		formData.append('token', $('#cocal_token').val());
+		formData.append('username', $('#cocal_user').val());
+		formData.append('password', $('#cocal_pass').val());
 
-	// show URL in infobox
-	$('#generator_url_link').attr("href", url);
-	$('#generator_url_link').text(url);
-	$('#generator_url').attr("class", "show");
+		$.ajax({
+			type: "POST",
+			url: cocal_proxy_url + "/generateHash.php",
+			data: formData,
+			processData: false,
+			contentType: false,
+			success: function (data) {
+				if ('success' == data.response) {
+					// retrieve generated hash
+					var campus_login_hash = data.hash;
+
+					// generate complete URL
+					var url = cocal_proxy_url + "/calendar.php?provider=" + $('#cocal_provider').val() + "&v=2&pass="+ securityCode +"&hash=" + campus_login_hash;
+
+					// show URL in infobox
+					$('#generator_url_link').attr("href", url);
+					$('#generator_url_link').text(url);
+					$('#generator_url').attr("class", "show");
+				}
+				else if ('error' == data.response) {
+					alert(data.message);
+				}
+			},
+			error: function () {
+				alert('Unbekannter Fehler!')
+			}
+		});
+	}
 }


### PR DESCRIPTION
Hallo Zusammen,

Ich habe mich ein bisschen hingesetzt, um das Cocal-System ein wenig umzuschreiben.
Ziel des Ganzen war es eine Verschlüsselung einzubauen, damit man anhand des Links nicht auf die Zugangsdaten kommen kann. Bisher war der "Hash" nur ein base64-Encodement. Ab jetzt werden die Zugangsdaten komplett verschlüsselt und dies anhand eines auf dem Server gespeicherten Verschlüsselungs-Key. Der Key ist einmalig und damit werden alle Zugangsdaten verschlüsselt, dh. es wird nach wie vor nichts Personenbezogenes gespeichert.
Damit jede Cocal-Installation einen eigenen Key besitzt, wird der lokal generiert indem beim Installieren eine Install-File ausgeführt wird.
Ein weiteres Feature ist ein Passwort, was für jeden Link gleich ist. Dieses wird eingesetzt um Brute-Force-Attacken oder Robot-Tätigkeiten zu vermeiden. Natürlich kann jeder dies umgehen, aber automatisierte Roboter werden damit Schwierigkeiten haben. Es geht darum, dass es mit Hilfe der Cocal-Installation nicht möglich ist, Uni-Server z.B. zu überlasten indem dauerhaft fehlerhafte Anfragen eingeschickt werden.

Und natürlich ist diese Cocal-Version backwards-compatible, damit ältere Links auch noch funktionieren.

Ich hoffe, die Änderungen sind erwünscht.
MfG,
Loïc

PS: Um eine robots.txt-Datei habe ich mich jetzt nicht gekümmert, wäre aber unter Umständen wünschenswert.
